### PR TITLE
Fixed exception when storage trying to parse non-parseable cookies

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,14 +25,13 @@ export class Storage {
     } else if (this.supportsStorage() && window.hasOwnProperty(`${storageType}Storage`))
       get = window[`${storageType}Storage`][name]
 
-    if (get)
-      return (
-        try {
-          JSON.parse(get)
-        } catch (e) {
-          return get
-        }
-      )
+    if (get) {
+      try {
+        return JSON.parse(get)
+      } catch (e) {
+        return get
+      }
+    }
 
     return get
   }

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,13 @@ export class Storage {
       get = window[`${storageType}Storage`][name]
 
     if (get)
-      return JSON.parse(get)
+      return (
+        try {
+          JSON.parse(get)
+        } catch (e) {
+          return get
+        }
+      )
 
     return get
   }


### PR DESCRIPTION
When user has some previously set cookies, including special symbols like `:`, `%`, storage returns
`SyntaxError: Unexpected token : in JSON at position N`.